### PR TITLE
Adds missing index.ts to npm package

### DIFF
--- a/packages/toi/package.json
+++ b/packages/toi/package.json
@@ -3,7 +3,12 @@
   "version": "1.0.5",
   "description": "Toi is a validator for TypeScript.",
   "main": "build/index.js",
-  "files": ["build/**/*.{js,js.map,d.ts,d.ts.map}", "LICENSE", "README.md"],
+  "files": [
+    "build/**/*.{js,js.map,d.ts,d.ts.map}",
+    "index.ts",
+    "LICENSE",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc",
     "test": "nyc mocha --require source-map-support/register --recursive build/**/*.spec.{js,jsx}",
@@ -13,7 +18,13 @@
     "type": "git",
     "url": "https://github.com/hf/toi"
   },
-  "keywords": ["typescript", "validator", "joi", "schema", "validation"],
+  "keywords": [
+    "typescript",
+    "validator",
+    "joi",
+    "schema",
+    "validation"
+  ],
   "author": "Stojan Dimitrovski <sdimitrovski@gmail.com>",
   "license": "MIT",
   "dependencies": {},
@@ -30,10 +41,22 @@
     "typescript": "^3.0.0"
   },
   "nyc": {
-    "include": ["build/**/*.js"],
-    "exclude": ["build/**/*.spec.js", "build/**/*.spec.jsx"],
-    "extension": [".js", ".jsx"],
-    "reporter": ["text-summary", "html", "lcovonly"],
+    "include": [
+      "build/**/*.js"
+    ],
+    "exclude": [
+      "build/**/*.spec.js",
+      "build/**/*.spec.jsx"
+    ],
+    "extension": [
+      ".js",
+      ".jsx"
+    ],
+    "reporter": [
+      "text-summary",
+      "html",
+      "lcovonly"
+    ],
     "sourceMap": true,
     "instrument": true
   }

--- a/packages/toi/package.json
+++ b/packages/toi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toi/toi",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Toi is a validator for TypeScript.",
   "main": "build/index.js",
   "files": [

--- a/packages/toi/package.json
+++ b/packages/toi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toi/toi",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Toi is a validator for TypeScript.",
   "main": "build/index.js",
   "files": [

--- a/packages/toix/package.json
+++ b/packages/toix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toi/toix",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Extra validators for Toi.",
   "main": "build/index.js",
   "files": [

--- a/packages/toix/package.json
+++ b/packages/toix/package.json
@@ -5,6 +5,7 @@
   "main": "build/index.js",
   "files": [
     "build/**/*.{js,js.map,d.ts,d.ts.map}",
+    "index.ts",
     "LICENSE",
     "README.md"
   ],


### PR DESCRIPTION
Adds `index.ts` in npm package to prevent build warning [1] when using the package in projects with  `sourceMaps` enabled. Tested locally with `npm pack` and it was packing the .ts file, should work with `npm publish`.

There might be a better solution by not including `ts.map` files and serving only `.js` and `.d.ts` files but that might need some research.

[1]: `(Emitted value instead of an instance of Error) Cannot find source file 'packages/index.ts': Error: Can't resolve '../index.ts' in...`