### PR TITLE
Add multiple validators for string values and alias for `any.only`

### DIFF
--- a/packages/toi/index.spec.ts
+++ b/packages/toi/index.spec.ts
@@ -183,6 +183,20 @@ describe("toi", () => {
         []
       ]
     });
+
+    assert(toi.any.values("a", "b", "c"), {
+      positive: ["a", "b", "c"],
+      negative: [
+        0,
+        NaN,
+        new String("a"),
+        new String("b"),
+        new String("c"),
+        false,
+        {},
+        []
+      ]
+    });
   });
 
   describe("str", () => {

--- a/packages/toi/index.ts
+++ b/packages/toi/index.ts
@@ -230,6 +230,11 @@ export namespace any {
         `value is not one of ${values.map(value => `${value}`).join(", ")}`
       )
     );
+
+  /**
+   * Alias for `only`. Check that the value is one of the provided values.
+   */
+  export const values = only;
 }
 
 /**

--- a/packages/toi/package.json
+++ b/packages/toi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toi/toi",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Toi is a validator for TypeScript.",
   "main": "build/index.js",
   "files": [

--- a/packages/toix/index.spec.ts
+++ b/packages/toix/index.spec.ts
@@ -315,6 +315,27 @@ describe("toix", () => {
       });
     });
 
+    describe("startsWith()", () => {
+      assert(toix.str.startsWith("test"), {
+        positive: ["test-123"],
+        negative: ["does-not-start-test-123"]
+      });
+    });
+
+    describe("endsWith()", () => {
+      assert(toix.str.endsWith("test"), {
+        positive: ["123-test"],
+        negative: ["does-not-end-test-123"]
+      });
+    });
+
+    describe("contains()", () => {
+      assert(toix.str.contains("test"), {
+        positive: ["123-test-contains"],
+        negative: ["does-not-contain"]
+      });
+    });
+
     describe("lowercase()", () => {
       transform(toix.str.lowercase(), {
         positive: [["", ""], ["hello", "hello"], ["HELLO", "hello"]]

--- a/packages/toix/index.spec.ts
+++ b/packages/toix/index.spec.ts
@@ -282,6 +282,39 @@ describe("toix", () => {
       });
     });
 
+    describe("urlAsString()", () => {
+      assert(toix.str.urlAsString(), {
+        positive: [
+          "http://www.google.com",
+          "https://www.google.com",
+          "http://google.com",
+          "http://www.google.com/imghp",
+          "http://g.co",
+          "ftp://google.com",
+          "http://кирилица.мкд",
+          "http://1337.net",
+          "http://foo.com/blah_(wikipedia)#cite-1",
+          "http://j.mp",
+          "http://.",
+          "http://0.0.0.0",
+          "h://test",
+          "ftps://foo.bar/",
+          "http:///a"
+        ],
+        negative: [
+          "www.google",
+          "www.google#.com",
+          "www.google-.co",
+          "www.-google.co",
+          "http://",
+          "http://??",
+          "///a",
+          ":// should fail",
+          "//"
+        ]
+      });
+    });
+
     describe("lowercase()", () => {
       transform(toix.str.lowercase(), {
         positive: [["", ""], ["hello", "hello"], ["HELLO", "hello"]]

--- a/packages/toix/index.ts
+++ b/packages/toix/index.ts
@@ -126,6 +126,42 @@ export namespace str {
     );
 
   /**
+   * Checks that the value begins with the characters of the specified string. Uses "String.startsWith()".
+   */
+  export const startsWith = <X extends string>(start: string) =>
+    wrap(
+      "str.startsWith",
+      allow<X, X>(
+        value => !!value.startsWith(start),
+        `value does not start with: ${start}`
+      )
+    );
+
+  /**
+   * Checks that the value ends with the characters of the specified string. Uses "String.endsWith()".
+   */
+  export const endsWith = <X extends string>(end: string) =>
+    wrap(
+      "str.endsWith",
+      allow<X, X>(
+        value => !!value.endsWith(end),
+        `value does not end with: ${end}`
+      )
+    );
+
+  /**
+   * Checks that the value contains the characters of the specified string in sequence. Uses "String.includes()".
+   */
+  export const contains = <X extends string>(part: string) =>
+    wrap(
+      "str.contains",
+      allow<X, X>(
+        value => !!value.includes(part),
+        `value does not contain: ${part}`
+      )
+    );
+
+  /**
    * Lowercases a string.
    */
   export const lowercase = <X extends string>() =>

--- a/packages/toix/index.ts
+++ b/packages/toix/index.ts
@@ -57,6 +57,28 @@ export namespace str {
       )
     );
 
+  /**
+   * Checks for a valid URL. Accepts an URL as string.
+   */
+  export const urlAsString = <X extends string>() =>
+    wrap(
+      "str.urlAsString",
+      transform<X, string>(
+        value => {
+          try {
+            new URL(value);
+            return value;
+          } catch (error) {
+            if (error instanceof TypeError) {
+              throw new ValidationError("Not a valid URL", value)
+            }
+
+            throw error;
+          }
+        }
+      )
+    );
+
 
   /**
    * Checks that the value is a GUID. By default it accepts any version of GUID and does not

--- a/packages/toix/index.ts
+++ b/packages/toix/index.ts
@@ -58,7 +58,7 @@ export namespace str {
     );
 
   /**
-   * Checks for a valid URL. Accepts an URL as string.
+   * Checks for a valid URL. Accepts an URL as string. Uses the 'URL()' constructor for validation.
    */
   export const urlAsString = <X extends string>() =>
     wrap(
@@ -69,11 +69,8 @@ export namespace str {
             new URL(value);
             return value;
           } catch (error) {
-            if (error instanceof TypeError) {
-              throw new ValidationError("Not a valid URL", value)
-            }
-
-            throw error;
+            // it will always be a type error
+            throw new ValidationError("Not a valid URL", value);
           }
         }
       )

--- a/packages/toix/package.json
+++ b/packages/toix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toi/toix",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Extra validators for Toi.",
   "main": "build/index.js",
   "files": [


### PR DESCRIPTION
`any.values` as alias for `any.only`
`urlAsString` - validates URLs in string representation. Uses the `new URL()` constructor instead of regex
`startsWith` - uses `String.startsWith()`
`endsWith` - uses `String.endsWith()`
`contains` - uses `String.includes`