### PR TITLE
Add missing object keys support, JSON, Base64, Base32 validation, others in @toi/toix

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ import * as toi from "@toi/toi";
 
 const isObject = toi
   .required() // make toi reject null or undefined
-  .and(toi.obj.is()) // forces that the value is an object
+  .and(toi.obj.isplain()) // forces that the value is a plain JS object
   .and(
     toi.obj.keys({
       num: toi.required().and(toi.num.is()),

--- a/packages/dynamo/index.spec.ts
+++ b/packages/dynamo/index.spec.ts
@@ -284,7 +284,10 @@ describe("dynamo", () => {
       transform(dynamo.binset.is(), {
         positive: [
           [{ BS: [""] }, [Buffer.alloc(0)]],
-          [{ BS: ["a"] }, [Buffer.from("a", "base64")]]
+          [
+            { BS: [Buffer.from("Hello, world!", "utf8").toString("base64")] },
+            [Buffer.from("Hello, world!", "utf8")]
+          ]
         ],
         negative: [
           { S: "x" },

--- a/packages/dynamo/index.ts
+++ b/packages/dynamo/index.ts
@@ -20,6 +20,7 @@
  */
 
 import * as toi from "@toi/toi";
+import * as toix from "@toi/toix";
 
 /**
  * DynamoDB stores numbers as strings in order to increase number compatibility
@@ -257,7 +258,10 @@ export namespace bin {
       .and(toi.obj.is())
       .and(
         toi.obj.keys({
-          B: toi.required().and(toi.str.is())
+          B: toi
+            .required()
+            .and(toi.str.is())
+            .and(toix.str.isbase64("rfc4648"))
         })
       )
       .and(pick());
@@ -290,7 +294,14 @@ export namespace binset {
             .required()
             .and(toi.array.is())
             .and(toi.array.min(1))
-            .and(toi.array.items(toi.required().and(toi.str.is())))
+            .and(
+              toi.array.items(
+                toi
+                  .required()
+                  .and(toi.str.is())
+                  .and(toix.str.isbase64("rfc4648"))
+              )
+            )
         })
       )
       .and(pick());

--- a/packages/dynamo/package.json
+++ b/packages/dynamo/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "@toi/toi": "^1.0.12",
-    "@toix/toi": "^1.0.12"
+    "@toi/toix": "^1.0.12"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.5",

--- a/packages/dynamo/package.json
+++ b/packages/dynamo/package.json
@@ -49,10 +49,22 @@
     "typescript": "^3.0.0"
   },
   "nyc": {
-    "include": ["build/**/*.js"],
-    "exclude": ["build/**/*.spec.js", "build/**/*.spec.jsx"],
-    "extension": [".js", ".jsx"],
-    "reporter": ["text-summary", "html", "lcovonly"],
+    "include": [
+      "build/**/*.js"
+    ],
+    "exclude": [
+      "build/**/*.spec.js",
+      "build/**/*.spec.jsx"
+    ],
+    "extension": [
+      ".js",
+      ".jsx"
+    ],
+    "reporter": [
+      "text-summary",
+      "html",
+      "lcovonly"
+    ],
     "sourceMap": true,
     "instrument": true
   }

--- a/packages/dynamo/package.json
+++ b/packages/dynamo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toi/dynamo",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Toi's Dynamo is a validator and transformer of DynamoDB objects for TypeScript.",
   "main": "build/index.js",
   "files": [
@@ -31,7 +31,10 @@
   ],
   "author": "Stojan Dimitrovski <sdimitrovski@gmail.com>",
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "@toi/toi": "^1.0.12",
+    "@toix/toi": "^1.0.12"
+  },
   "devDependencies": {
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.0.0",
@@ -46,22 +49,10 @@
     "typescript": "^3.0.0"
   },
   "nyc": {
-    "include": [
-      "build/**/*.js"
-    ],
-    "exclude": [
-      "build/**/*.spec.js",
-      "build/**/*.spec.jsx"
-    ],
-    "extension": [
-      ".js",
-      ".jsx"
-    ],
-    "reporter": [
-      "text-summary",
-      "html",
-      "lcovonly"
-    ],
+    "include": ["build/**/*.js"],
+    "exclude": ["build/**/*.spec.js", "build/**/*.spec.jsx"],
+    "extension": [".js", ".jsx"],
+    "reporter": ["text-summary", "html", "lcovonly"],
     "sourceMap": true,
     "instrument": true
   }

--- a/packages/toi/index.spec.ts
+++ b/packages/toi/index.spec.ts
@@ -500,6 +500,22 @@ describe("toi", () => {
       );
     });
 
+    describe("keys({ a: toi.required().and(toi.num.is()), b: toi.num.is() }, { missing: { a: true } })", () => {
+      assert(
+        toi.obj.keys(
+          {
+            a: toi.required().and(toi.num.is()),
+            b: toi.num.is()
+          },
+          { missing: ["a"] }
+        ),
+        {
+          positive: [{ a: 0, b: 0 }],
+          negative: [{ a: 0 }, { b: 0 }, {}]
+        }
+      );
+    });
+
     describe("xor(['a', 'b'])", () => {
       assert(toi.obj.xor(["a", "b"]), {
         positive: [{ a: 0, c: 1 }, { b: 0, c: 1 }],

--- a/packages/toi/index.spec.ts
+++ b/packages/toi/index.spec.ts
@@ -402,7 +402,7 @@ describe("toi", () => {
   });
 
   describe("obj", () => {
-    describe("is", () => {
+    describe("is()", () => {
       assert(toi.obj.is(), {
         positive: [
           [],
@@ -413,6 +413,17 @@ describe("toi", () => {
           new Boolean(false)
         ],
         negative: [NaN, false, "", 0]
+      });
+    });
+
+    describe("isplain()", () => {
+      assert(toi.obj.isplain(), {
+        positive: [{}, { actAsObject: true, __proto__: Object.prototype }],
+        negative: [
+          { actAsFunction: true, __proto__: Function.prototype },
+          [],
+          new String()
+        ]
       });
     });
 

--- a/packages/toi/index.spec.ts
+++ b/packages/toi/index.spec.ts
@@ -484,6 +484,22 @@ describe("toi", () => {
       });
     });
 
+    describe("keys({ a: toi.num.is(), b: toi.num.is() }, { missing: { a: true } })", () => {
+      assert(
+        toi.obj.keys(
+          {
+            a: toi.num.is(),
+            b: toi.num.is()
+          },
+          { missing: ["a"] }
+        ),
+        {
+          positive: [{ a: 0, b: 0 }, { b: 0 }],
+          negative: [{ a: 0 }, {}]
+        }
+      );
+    });
+
     describe("xor(['a', 'b'])", () => {
       assert(toi.obj.xor(["a", "b"]), {
         positive: [{ a: 0, c: 1 }, { b: 0, c: 1 }],

--- a/packages/toi/index.ts
+++ b/packages/toi/index.ts
@@ -727,6 +727,11 @@ export namespace obj {
           if (!Object.getOwnPropertyDescriptor(value, key)) {
             if (!missing[key]) {
               throw new ValidationError(`key ${key} in value is missing`, key);
+            } else {
+              // still run the validator even if the value is missing, so that if
+              // someone has said that the key can be missing but they've put a required validator
+              // the validation will fail
+              output[key] = (structure as any)[key]((value as any)[key]);
             }
           } else {
             output[key] = (structure as any)[key]((value as any)[key]);

--- a/packages/toi/index.ts
+++ b/packages/toi/index.ts
@@ -600,6 +600,8 @@ export namespace array {
 export namespace obj {
   /**
    * Checks that the value is a JavaScript object excluding `null`.
+   * Usually when validating HTTP body input you want to use toi.obj.isplain() as that
+   * can mitigate some prototype-pollution attacks.
    */
   export const is = <X>() =>
     wrap(
@@ -607,6 +609,25 @@ export namespace obj {
       allow<X, object>(
         value => null !== value && "object" === typeof value,
         `value is not an object type`
+      )
+    );
+
+  /**
+   * Checks that the object is a plain JavaScript object, i.e. an object whose
+   * prototype is Object.prototype and no attempt has been made to insert a
+   * __proto__ property as a way to change the object's prototype. `null` is not regarded
+   * as an object, though it is.
+   */
+  export const isplain = <X>() =>
+    wrap(
+      "obj.isplain",
+      allow<X, object>(
+        value =>
+          null !== value &&
+          "object" === typeof value &&
+          !Object.getOwnPropertyDescriptor(value, "__proto__") &&
+          Object.prototype === Object.getPrototypeOf(value),
+        "value is not an object or its prototype is not Object.prototype"
       )
     );
 

--- a/packages/toi/package.json
+++ b/packages/toi/package.json
@@ -18,7 +18,13 @@
     "type": "git",
     "url": "https://github.com/hf/toi"
   },
-  "keywords": ["typescript", "validator", "joi", "schema", "validation"],
+  "keywords": [
+    "typescript",
+    "validator",
+    "joi",
+    "schema",
+    "validation"
+  ],
   "author": "Stojan Dimitrovski <sdimitrovski@gmail.com>",
   "license": "MIT",
   "dependencies": {},
@@ -35,10 +41,22 @@
     "typescript": "^3.0.0"
   },
   "nyc": {
-    "include": ["build/**/*.js"],
-    "exclude": ["build/**/*.spec.js", "build/**/*.spec.jsx"],
-    "extension": [".js", ".jsx"],
-    "reporter": ["text-summary", "html", "lcovonly"],
+    "include": [
+      "build/**/*.js"
+    ],
+    "exclude": [
+      "build/**/*.spec.js",
+      "build/**/*.spec.jsx"
+    ],
+    "extension": [
+      ".js",
+      ".jsx"
+    ],
+    "reporter": [
+      "text-summary",
+      "html",
+      "lcovonly"
+    ],
     "sourceMap": true,
     "instrument": true
   }

--- a/packages/toi/package.json
+++ b/packages/toi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toi/toi",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Toi is a validator for TypeScript.",
   "main": "build/index.js",
   "files": [
@@ -18,13 +18,7 @@
     "type": "git",
     "url": "https://github.com/hf/toi"
   },
-  "keywords": [
-    "typescript",
-    "validator",
-    "joi",
-    "schema",
-    "validation"
-  ],
+  "keywords": ["typescript", "validator", "joi", "schema", "validation"],
   "author": "Stojan Dimitrovski <sdimitrovski@gmail.com>",
   "license": "MIT",
   "dependencies": {},
@@ -41,22 +35,10 @@
     "typescript": "^3.0.0"
   },
   "nyc": {
-    "include": [
-      "build/**/*.js"
-    ],
-    "exclude": [
-      "build/**/*.spec.js",
-      "build/**/*.spec.jsx"
-    ],
-    "extension": [
-      ".js",
-      ".jsx"
-    ],
-    "reporter": [
-      "text-summary",
-      "html",
-      "lcovonly"
-    ],
+    "include": ["build/**/*.js"],
+    "exclude": ["build/**/*.spec.js", "build/**/*.spec.jsx"],
+    "extension": [".js", ".jsx"],
+    "reporter": ["text-summary", "html", "lcovonly"],
     "sourceMap": true,
     "instrument": true
   }

--- a/packages/toix/index.spec.ts
+++ b/packages/toix/index.spec.ts
@@ -351,6 +351,78 @@ describe("toix", () => {
         negative: ["+012", "+1", "+", "1", "+1234567891234567"]
       });
     });
+
+    describe("isbase64() RFC4648 not-url", () => {
+      toix.str.isbase64(null as any);
+      toix.str.isbase64("rfc4648");
+      toix.str.isbase64("default");
+
+      try {
+        toix.str.isbase64("rfc2045" as any);
+        throw new Error("Allowed to specify RFC2045 but not implemented!");
+      } catch (error) {}
+
+      assert(toix.str.isbase64(), {
+        positive: [
+          "",
+          "XX==",
+          "XXX=",
+          "XXXX",
+          "11112222",
+          "111122==",
+          "1111222=",
+          "111122223333",
+          "1111222233==",
+          "11112222333="
+        ],
+        negative: [
+          "X",
+          "XX",
+          "XXX",
+          "#",
+          "____",
+          "----",
+          "==",
+          "=",
+          "====",
+          "X===",
+          "X==",
+          "X="
+        ]
+      });
+    });
+
+    describe("isbase64('rfc4648-url')", () => {
+      toix.str.isbase64("url");
+      toix.str.isbase64("rfc4648-url");
+
+      assert(toix.str.isbase64("rfc4648-url"), {
+        positive: [
+          "",
+          "XX",
+          "XXX",
+          "1111",
+          "11112222",
+          "1111222",
+          "111122",
+          "1111222=",
+          "111122==",
+          "____--=="
+        ],
+        negative: [
+          "X",
+          "#",
+          "////",
+          "++++",
+          "==",
+          "=",
+          "====",
+          "X===",
+          "X==",
+          "X="
+        ]
+      });
+    });
   });
 
   describe("bool", () => {

--- a/packages/toix/index.spec.ts
+++ b/packages/toix/index.spec.ts
@@ -407,4 +407,19 @@ describe("toix", () => {
       });
     });
   });
+
+  describe("json", () => {
+    describe("parse()", () => {
+      transform(toix.json.parse(), {
+        positive: [[JSON.stringify({}), {}]],
+        negative: ["", "{", "["]
+      });
+    });
+
+    describe("stringify()", () => {
+      transform(toix.json.stringify(), {
+        positive: [[{}, "{}"]]
+      });
+    });
+  });
 });

--- a/packages/toix/index.spec.ts
+++ b/packages/toix/index.spec.ts
@@ -353,6 +353,41 @@ describe("toix", () => {
       });
     });
 
+    describe("split('.')", () => {
+      transform(toix.str.split("."), {
+        positive: [["hello.world", ["hello", "world"]]],
+        negative: []
+      });
+    });
+
+    describe("split(/[.]/)", () => {
+      transform(toix.str.split(/[.]/), {
+        positive: [["hello.world", ["hello", "world"]]],
+        negative: []
+      });
+    });
+
+    describe("replace('.', ':')", () => {
+      transform(toix.str.replace(".", ":"), {
+        positive: [[".", ":"]],
+        negative: []
+      });
+    });
+
+    describe("replace(/[.]/, ':')", () => {
+      transform(toix.str.replace(/[.]/, ":"), {
+        positive: [[".", ":"]],
+        negative: []
+      });
+    });
+
+    describe("replace(/[.]/, () => ':')", () => {
+      transform(toix.str.replace(/[.]/, () => ":"), {
+        positive: [[".", ":"]],
+        negative: []
+      });
+    });
+
     describe("phoneNumber()", () => {
       assert(toix.str.phoneNumber(), {
         positive: ["+8006927753", "+3891234567", "8006927753"],

--- a/packages/toix/index.spec.ts
+++ b/packages/toix/index.spec.ts
@@ -273,8 +273,16 @@ describe("toix", () => {
       });
     });
 
-    describe("urlAsString()", () => {
-      assert(toix.str.urlAsString(), {
+    describe("DEPRECATED urlAsString()", () => {
+      it("should redirect to isurl()", () => {
+        if (toix.str.urlAsString !== toix.str.isurl) {
+          throw new Error("toix.str.urlAsString is not toix.str.isurl!");
+        }
+      });
+    });
+
+    describe("isurl()", () => {
+      assert(toix.str.isurl(), {
         positive: [
           "http://www.google.com",
           "https://www.google.com",

--- a/packages/toix/index.spec.ts
+++ b/packages/toix/index.spec.ts
@@ -423,6 +423,107 @@ describe("toix", () => {
         ]
       });
     });
+
+    describe("isbase32() RFC4648 not-url", () => {
+      toix.str.isbase32(null as any);
+      toix.str.isbase32("default");
+      toix.str.isbase32("rfc4648");
+
+      try {
+        toix.str.isbase32("z-base" as any);
+        throw new Error(
+          "Allowed the use of z-base-32 encoding but it is not implemented."
+        );
+      } catch (error) {}
+
+      assert(toix.str.isbase32(), {
+        positive: [
+          "",
+          "XXXXYYYY", // 40 bits
+          "XX======", // 8 bits
+          "XXXX====", // 16 bits
+          "XXXXY===", // 24 bits
+          "XXXXYYY=", // 32 bits
+          "22227777XXXXYYYY", // 40 + 40 bits
+          "22227777XX======", // 40 + 8 bits
+          "22227777XXXX====", // 40 + 16 bits
+          "22227777XXXXY===", // 40 + 24 bits
+          "22227777XXXXYYY=" //  40 + 32 bits
+        ],
+        negative: [
+          "00000000",
+          "11111111",
+          "88888888",
+          "99999999",
+          "2222333300000000",
+          "2222333311111111",
+          "2222333388888888",
+          "2222333399999999",
+          "========",
+          "======",
+          "====",
+          "===",
+          "=",
+          "XXXXYYYYX=======",
+          "XXXXYYYYXXX=====",
+          "XXXXYYYYXXXXXX==",
+          "aaaaaaaaaaaaaaa=" //  40 + 32 bits
+        ]
+      });
+
+      describe("isbase32('rfc4648-url')", () => {
+        toix.str.isbase32("url");
+
+        assert(toix.str.isbase32("rfc4648-url"), {
+          positive: [
+            "",
+            "XXXXYYYY", // 40 bits
+            "XX======", // 8 bits
+            "XXXX====", // 16 bits
+            "XXXXY===", // 24 bits
+            "XXXXYYY=", // 32 bits
+            "22227777XXXXYYYY", // 40 + 40 bits
+            "22227777XX======", // 40 + 8 bits
+            "22227777XXXX====", // 40 + 16 bits
+            "22227777XXXXY===", // 40 + 24 bits
+            "22227777XXXXYYY=", //  40 + 32 bits
+            "XXXXYYYY", // 40 bits
+            "XX", // 8 bits
+            "XXXX", // 16 bits
+            "XXXXY", // 24 bits
+            "XXXXYYY", // 32 bits
+            "22227777XXXXYYYY", // 40 + 40 bits
+            "22227777XX", // 40 + 8 bits
+            "22227777XXXX", // 40 + 16 bits
+            "22227777XXXXY", // 40 + 24 bits
+            "22227777XXXXYYY" //  40 + 32 bits
+          ],
+          negative: [
+            "00000000",
+            "11111111",
+            "88888888",
+            "99999999",
+            "2222333300000000",
+            "2222333311111111",
+            "2222333388888888",
+            "2222333399999999",
+            "========",
+            "======",
+            "====",
+            "===",
+            "=",
+            "XXXXYYYYX=======",
+            "XXXXYYYYXXX=====",
+            "XXXXYYYYXXXXXX==",
+            "aaaaaaaaaaaaaaa=", //  40 + 32 bits
+            "XXXXYYYYX",
+            "XXXXYYYYXXX",
+            "XXXXYYYYXXXXXX",
+            "aaaaaaaaaaaaaaa" //  40 + 32 bits
+          ]
+        });
+      });
+    });
   });
 
   describe("bool", () => {

--- a/packages/toix/index.ts
+++ b/packages/toix/index.ts
@@ -232,3 +232,33 @@ export namespace bool {
       })
     );
 }
+
+/**
+ * JSON parsing, stringifying.
+ */
+export namespace json {
+  /**
+   * Parse a string into an unknown JS value.
+   */
+  export const parse = <X extends string>(
+    parser: (text: X) => unknown = JSON.parse
+  ) =>
+    wrap(
+      "json.parse",
+      transform<X, unknown>(value => {
+        try {
+          return parser(value);
+        } catch (error) {
+          throw new ValidationError("invalid json", value, error);
+        }
+      })
+    );
+
+  /**
+   * Stringify some unknown JS value to a JSON string.
+   */
+  export const stringify = <X>(
+    stringifier: (value: X) => string = JSON.stringify
+  ) =>
+    wrap("json.stringify", transform<X, string>(value => stringifier(value)));
+}

--- a/packages/toix/index.ts
+++ b/packages/toix/index.ts
@@ -26,8 +26,7 @@ export namespace str {
     );
 
   /**
-   * Checks for a valid URL. Accepts an URL, and optional
-   * parameters like protocol and port.
+   * Checks and parses a URL-string into a URL object.
    */
   export const url = <X extends string, R extends string, O extends string>(
     options: { protocol?: R; port?: O } = {}
@@ -35,51 +34,63 @@ export namespace str {
     wrap(
       "str.url",
       transform<X, URL & { protocol: R; port: O }>(value => {
+        let url: URL;
+
         try {
-          const url = new URL(value);
-
-          if (options && options.port && options.port !== url.port) {
-            throw new ValidationError(`Invalid port: ${options.port}`, value);
-          }
-
-          if (
-            options &&
-            options.protocol &&
-            options.protocol !== url.protocol
-          ) {
-            throw new ValidationError(
-              `Invalid protocol: ${options.protocol}`,
-              value
-            );
-          }
-
-          return url as URL & { protocol: R; port: O };
+          url = new URL(value);
         } catch (error) {
-          if (error instanceof TypeError) {
-            throw new ValidationError("Not a valid URL", value);
-          }
-
-          throw error;
+          throw new ValidationError(
+            "value does not look like a proper URL",
+            value
+          );
         }
+
+        if (options && options.port && options.port !== url.port) {
+          throw new ValidationError(
+            `value is a proper URL but the expected port ${
+              options.port
+            } does not match ${url.port}`,
+            value
+          );
+        }
+
+        if (options && options.protocol && options.protocol !== url.protocol) {
+          throw new ValidationError(
+            `value is a proper URL but the expected protocol '${
+              options.protocol
+            }' does not match '${url.protocol}'`,
+            value
+          );
+        }
+
+        return url as URL & { protocol: R; port: O };
       })
     );
 
   /**
    * Checks for a valid URL. Accepts an URL as string. Uses the 'URL()' constructor for validation.
    */
-  export const urlAsString = <X extends string>() =>
+  export const isurl = <X extends string>() =>
     wrap(
-      "str.urlAsString",
+      "str.isurl",
       transform<X, string>(value => {
         try {
           new URL(value);
           return value;
         } catch (error) {
           // it will always be a type error
-          throw new ValidationError("Not a valid URL", value);
+          throw new ValidationError(
+            "value does not look like a valid URL",
+            value
+          );
         }
       })
     );
+
+  /**
+   * @deprecated Please use isurl.
+   */
+  export const urlAsString = isurl;
 
   /**
    * Checks that the value is a GUID. By default it accepts any version of GUID and does not

--- a/packages/toix/index.ts
+++ b/packages/toix/index.ts
@@ -236,6 +236,46 @@ export namespace str {
       )
     );
   };
+
+  /**
+   * Checks that the string contains valid Base32 encoding.
+   *
+   * There are two supported variants "rfc4648" ("default") and "rfc4648-url" ("url")
+   * that implement the RFC4648 standard for Base32 encoding. It's important to note
+   * that this standard does not allow spaces, CR, LF or other characters. It also does
+   * not allow lowercase letters to be used.
+   *
+   * The "url" variant makes padding optional.
+   *
+   * This also checks the length of the message!
+   */
+  export const isbase32 = <X extends string>(
+    variant: "default" | "rfc4648" | "url" | "rfc4648-url" = "rfc4648"
+  ) => {
+    if ("default" === variant || !variant) {
+      variant = "rfc4648";
+    } else if ("url" === variant) {
+      variant = "rfc4648-url";
+    }
+
+    let regex: RegExp;
+
+    if ("rfc4648" === variant) {
+      regex = /^([A-Z2-7]{8})*($|[A-Z2-7]{2}={6}$|[A-Z2-7]{4}={4}$|[A-Z2-7]{5}={3}$|[A-Z2-7]{7}={1}$)$/;
+    } else if ("rfc4648-url" === variant) {
+      regex = /^([A-Z2-7]{8})*($|[A-Z2-7]{2}(={6})?$|[A-Z2-7]{4}(={4})?$|[A-Z2-7]{5}(={3})?$|[A-Z2-7]{7}(={1})?$)$/;
+    } else {
+      throw new Error(`Unknown Base32 variant ${variant}`);
+    }
+
+    return wrap(
+      "str.isbase32",
+      allow<X, X>(
+        value => !!value.match(regex),
+        `value is not a valid ${variant} base32, it should match ${regex}`
+      )
+    );
+  };
 }
 
 /**

--- a/packages/toix/index.ts
+++ b/packages/toix/index.ts
@@ -197,6 +197,45 @@ export namespace str {
         "value does not match E.164 numbering plan"
       )
     );
+
+  /**
+   * Checks that a string contains a valid Base64 encoding.
+   *
+   * There are two supported variants "rfc4648" ("default") and "rfc4648-url" ("url") that
+   * follow the RFC4648 Base64 encoding standard. It's important to note that this
+   * RFC does not support adding spaces, CR or LF characters in the string!
+   * That is RFC2045 which is not supported by this function at this time.
+   *
+   * This function also strictly checks the number of characters -- the string length
+   * must be a multiple of 4 with padding as necessary (and when required).
+   */
+  export const isbase64 = <X extends string>(
+    variant: "default" | "rfc4648" | "url" | "rfc4648-url" = "rfc4648"
+  ) => {
+    if ("default" === variant || !variant) {
+      variant = "rfc4648";
+    } else if ("url" === variant) {
+      variant = "rfc4648-url";
+    }
+
+    let regex: RegExp;
+
+    if ("rfc4648" === variant) {
+      regex = /^([a-z0-9\/+]{4})*($|[a-z0-9\/+]{3}=$|[a-z0-9\/+]{2}==$)$/i;
+    } else if ("rfc4648-url" === variant) {
+      regex = /^([a-z0-9_-]{4})*($|[a-z0-9_-]{3}=?$|[a-z0-9_-]{2}(==)?$)$/i;
+    } else {
+      throw new Error(`Unknown Base64 variant ${variant}`);
+    }
+
+    return wrap(
+      "str.isbase64",
+      allow<X, X>(
+        value => !!value.match(regex),
+        `value is not a valid ${variant} base64, it should match ${regex}`
+      )
+    );
+  };
 }
 
 /**

--- a/packages/toix/index.ts
+++ b/packages/toix/index.ts
@@ -287,6 +287,36 @@ export namespace str {
       )
     );
   };
+
+  /**
+   * Split a string into multiple strings at a specified pattern. Exactly like String#split.
+   */
+  export const split = <X extends string>(
+    pattern: string | RegExp,
+    limit?: number
+  ) =>
+    wrap(
+      "str.split",
+      transform<X, string[]>(value => value.split(pattern, limit))
+    );
+
+  /**
+   * Replaces a pattern within a string with another string. Exactly like String#replace.
+   */
+  export const replace = <X extends string>(
+    pattern: string | RegExp,
+    replacement: string | ((substring: string, ...args: any[]) => string)
+  ) =>
+    wrap(
+      "str.replace",
+      transform<X, string>(value => {
+        if ("string" === typeof replacement) {
+          return value.replace(pattern, replacement);
+        }
+
+        return value.replace(pattern, replacement);
+      })
+    );
 }
 
 /**

--- a/packages/toix/package.json
+++ b/packages/toix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toi/toix",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Extra validators for Toi.",
   "main": "build/index.js",
   "files": [
@@ -18,14 +18,7 @@
     "type": "git",
     "url": "https://github.com/hf/toi"
   },
-  "keywords": [
-    "toi",
-    "typescript",
-    "validator",
-    "joi",
-    "schema",
-    "validation"
-  ],
+  "keywords": ["toi", "typescript", "validator", "joi", "schema", "validation"],
   "author": "Stojan Dimitrovski <sdimitrovski@gmail.com>",
   "license": "MIT",
   "dependencies": {
@@ -47,22 +40,10 @@
     "typescript": "^3.0.0"
   },
   "nyc": {
-    "include": [
-      "build/**/*.js"
-    ],
-    "exclude": [
-      "build/**/*.spec.js",
-      "build/**/*.spec.jsx"
-    ],
-    "extension": [
-      ".js",
-      ".jsx"
-    ],
-    "reporter": [
-      "text-summary",
-      "html",
-      "lcovonly"
-    ],
+    "include": ["build/**/*.js"],
+    "exclude": ["build/**/*.spec.js", "build/**/*.spec.jsx"],
+    "extension": [".js", ".jsx"],
+    "reporter": ["text-summary", "html", "lcovonly"],
     "sourceMap": true,
     "instrument": true
   }

--- a/packages/toix/package.json
+++ b/packages/toix/package.json
@@ -18,7 +18,14 @@
     "type": "git",
     "url": "https://github.com/hf/toi"
   },
-  "keywords": ["toi", "typescript", "validator", "joi", "schema", "validation"],
+  "keywords": [
+    "toi",
+    "typescript",
+    "validator",
+    "joi",
+    "schema",
+    "validation"
+  ],
   "author": "Stojan Dimitrovski <sdimitrovski@gmail.com>",
   "license": "MIT",
   "dependencies": {
@@ -40,10 +47,22 @@
     "typescript": "^3.0.0"
   },
   "nyc": {
-    "include": ["build/**/*.js"],
-    "exclude": ["build/**/*.spec.js", "build/**/*.spec.jsx"],
-    "extension": [".js", ".jsx"],
-    "reporter": ["text-summary", "html", "lcovonly"],
+    "include": [
+      "build/**/*.js"
+    ],
+    "exclude": [
+      "build/**/*.spec.js",
+      "build/**/*.spec.jsx"
+    ],
+    "extension": [
+      ".js",
+      ".jsx"
+    ],
+    "reporter": [
+      "text-summary",
+      "html",
+      "lcovonly"
+    ],
     "sourceMap": true,
     "instrument": true
   }


### PR DESCRIPTION
Adds `toi.obj.isplain` to check for plain JS objects.
Adds support for JSON parsing.
Adds support to split, replace a string.
Adds support for objects with missing keys.
Adds Base64 and Base32 strict validation based on [RFC4648](https://tools.ietf.org/html/rfc4648).

Deprecating `toix.str.urlAsString` and replacing it with `toix.str.isurl`.