### PR TITLE
Update for compatibility with TypeScript 3.5

### DIFF
--- a/packages/dynamo/index.ts
+++ b/packages/dynamo/index.ts
@@ -65,8 +65,6 @@ export const nullable = <X>() =>
     })
   );
 
-const returnNull = () => toi.wrap("dynamo.null", toi.transform(() => null));
-
 /**
  * Extracts null from the dreaded { NULL: true } DynamoDB value.
  * (But only null and does not accept anything else!)
@@ -75,7 +73,7 @@ export const isnull = () =>
   toi.obj
     .is()
     .and(toi.obj.keys({ NULL: toi.required().and(toi.bool.truth()) }))
-    .and(returnNull());
+    .and(toi.wrap("dynamo.null", toi.transform<any, null>(() => null)));
 
 /**
  * Transformers for the { S: string } DynamoDB value.

--- a/packages/dynamo/package.json
+++ b/packages/dynamo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toi/dynamo",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Toi's Dynamo is a validator and transformer of DynamoDB objects for TypeScript.",
   "main": "build/index.js",
   "files": [

--- a/packages/toi/index.ts
+++ b/packages/toi/index.ts
@@ -122,7 +122,7 @@ export function wrap<I, X>(
     [name]: (value: I) => func(value)
   };
 
-  const validatorFunction = container[name];
+  const validatorFunction: any = container[name];
 
   return Object.assign(validatorFunction, {
     and: <B>(validator: Validator<X, B>): Validator<I, B> =>
@@ -131,6 +131,7 @@ export function wrap<I, X>(
       )
   });
 }
+
 /**
  * Wraps a boolean-returning function as a function ready-to-use in {@link #wrap}.
  *
@@ -169,7 +170,7 @@ export function allow<I, X>(bool: (value: I) => boolean, failure: string) {
 export function transform<I, X>(transformer: (value: I) => X) {
   return (value: I): I extends null | undefined ? X | null | undefined : X => {
     if (null === value || undefined === value) {
-      return value;
+      return value as any;
     }
 
     return transformer(value) as any;

--- a/packages/toi/package.json
+++ b/packages/toi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toi/toi",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Toi is a validator for TypeScript.",
   "main": "build/index.js",
   "files": [

--- a/packages/toix/package.json
+++ b/packages/toix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toi/toix",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Extra validators for Toi.",
   "main": "build/index.js",
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1427,10 +1427,10 @@ type-detect@^4.0.0:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-typescript@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
-  integrity sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==
+typescript@^3.5.0:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
@ivasilov Noticed that toi does not build properly with TypeScript 3.5. This was mainly due to stricter inference regarding discriminated union and function types introduced in TypeScript 3.5. 

toi, toix and dynamo remain compatible with TypeScript 3.X.X.