### PR TITLE
Added num.isNumberType and repurposed num.isNaN

### DIFF
--- a/packages/toi/index.spec.ts
+++ b/packages/toi/index.spec.ts
@@ -219,10 +219,17 @@ describe("toi", () => {
       });
     });
 
-    describe("isNaN", () => {
-      assert(toi.num.isNaN(), {
+    describe("isNumberType", () => {
+      assert(toi.num.isNumberType(), {
         positive: [0, 1, -1, NaN],
         negative: [false, "", "-1", "0", "1", {}, [], new Number(0)]
+      });
+    });
+
+    describe("isNaN", () => {
+      assert(toi.num.isNaN(), {
+        positive: [NaN],
+        negative: [0, 1, -1, 0.1, -0.1, false, "", "-1", "0", "1", {}, [], new Number(0)]
       });
     });
 

--- a/packages/toi/index.ts
+++ b/packages/toi/index.ts
@@ -331,10 +331,22 @@ export namespace num {
   /**
    * Check that the value is a `number` including `NaN`.
    */
-  export const isNaN = <X>() =>
+  export const isNumberType = <X>() =>
     wrap(
       "num.isNaN",
       allow<X, number>(value => "number" === typeof value, "value is not a number type")
+    );
+
+  /**
+   * Check that the value is `NaN`.
+   */
+  export const isNaN = <X>() =>
+    wrap(
+      "num.isNaN",
+      allow<X, number>(
+        value => "number" === typeof value && Number.isNaN(value),
+        "value is not NaN"
+      )
     );
 
   /**


### PR DESCRIPTION
Adds `num.IsNumberType` validator which fixes #138 
Re-purposes `num.isNaN` to reflect its actual function.